### PR TITLE
Don't override meta fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 python:
   - "3.6"
 before_script:

--- a/euctr/crawl/schema.sql
+++ b/euctr/crawl/schema.sql
@@ -194,7 +194,7 @@ AS $function$
                       NEW.meta_updated := now();
                       RETURN NEW;
                     END;
-                    $function$
+                    $function$;
 
 CREATE TRIGGER euctr_set_meta_updated BEFORE UPDATE ON euctr FOR EACH ROW EXECUTE PROCEDURE set_meta_updated();
 
@@ -212,4 +212,3 @@ GRANT ALL ON TABLE euctr TO euctr;
 --
 -- PostgreSQL database dump complete
 --
-


### PR DESCRIPTION
These were not-nullable in the production database, so we also
reproduce the production database exactly as-is