### PR TITLE
Updated Email Address

### DIFF
--- a/euctr/templates/_base.html
+++ b/euctr/templates/_base.html
@@ -85,7 +85,7 @@
         <div class="container">
         Built by the <a href="https://ebmdatalab.net">Evidence-Based Medicine
           Data Lab</a>, University of Oxford.
-          <a href="mailto:hello@ebmdatalab.net">Get in touch</a>.
+          <a href="mailto:ebmdatalab@phc.ox.ac.uk">Get in touch</a>.
         </div>
       </footer>
     {% endif %}


### PR DESCRIPTION
Updated the get-in-touch email address to ebmdatalab@phc.ox.ac.uk to avoid spam issues with hello@ebmdatalab.net