### PR TITLE
Pin dependencies to last known good versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ csscompressor==0.9.4
 pandas==0.19.2
 gevent==1.2.1
 gunicorn==19.6.0
+numpy==1.16.2
+pandas==0.19.2
 psycopg2-binary==2.7.6.1
 selenium==3.5.0
 atomicwrites==1.1.5
@@ -16,6 +18,10 @@ dataset==1.0.1
 scrapy-crawlera==1.2.4
 google-cloud-bigquery==1.3.0
 google-cloud-storage==1.13.0
+google-api-core==1.16.0
 fabric3
 testing.postgresql==1.3.0
 attrs==18.2.0
+Automat==0.8.0
+Twisted==19.10.0
+six==1.11.0


### PR DESCRIPTION
* Un-pinned things got updated upstream & broke CI. Pin them so that things work again.
* Fixes Travis CI, although not Github Actions