### PR TITLE
Remove huge margin from about us page

### DIFF
--- a/euctr/static/scss/site.scss
+++ b/euctr/static/scss/site.scss
@@ -1085,10 +1085,6 @@ by <html> element's pix value. */
   visibility: hidden;
 }
 
-#about-page + hr + footer {
-  margin-bottom: 80em;
-}
-
 /****************************************************************/
 /* Stripes (mainly on chart on sponsor page) */
 


### PR DESCRIPTION
* I'm not completely sure what this was intended to achieve ( it might be to do with a nearby comment that references https://github.com/twbs/bootstrap/issues/1768 ), but after fixing https://github.com/ebmdatalab/euctr-tracker-code/pull/85 it now seems to do more harm than good.