### PR TITLE
Bump django from 1.11.29 to 2.2.24

### DIFF
--- a/euctr/frontend/tests/databaseless_runner.py
+++ b/euctr/frontend/tests/databaseless_runner.py
@@ -5,7 +5,7 @@ from django.test.runner import DiscoverRunner
 class DatabaselessTestRunner(DiscoverRunner):
     """A test suite runner that does not set up and tear down a database."""
 
-    def setup_databases(self):
+    def setup_databases(self, *args, **kwargs):
         """Overrides DjangoTestSuiteRunner"""
         pass
 

--- a/euctr/frontend/views.py
+++ b/euctr/frontend/views.py
@@ -5,8 +5,8 @@ import signal
 
 from django.shortcuts import render
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.http import HttpResponse
+from django.urls import reverse
 
 import selenium.webdriver
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.0.13
+Django==2.1.15
 django_compressor==2.1.1
 django-libsass==0.7
 csscompressor==0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.29
+Django==2.0.13
 django_compressor==2.1.1
 django-libsass==0.7
 csscompressor==0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.1.15
+Django==2.2.24
 django_compressor==2.1.1
 django-libsass==0.7
 csscompressor==0.9.4


### PR DESCRIPTION
This bumps Django from 1.11.x to 2.2.x via the intermediate minor releases.

There are only a couple of non-version-update tweaks to handle changes or deprecated bits from Django.

I also tested further updates, but immediately hit csscompressor using some outdated imports (`django.six`), so we'll need to swap it out for something getting maintenance updates (probably django-compressor).