### PR TITLE
Use compat Plausible Analytics code

### DIFF
--- a/euctr/templates/_base.html
+++ b/euctr/templates/_base.html
@@ -28,7 +28,7 @@
       {% include "_load_js.html" %}
     {% endif %}
 
-    <script async defer data-domain="eu.trialstracker.net" src="https://plausible.io/js/plausible.js"></script>
+    <script id="plausible" defer data-domain="eu.trialstracker.net" src="https://plausible.io/js/plausible.compat.js"></script>
   </head>
 
   {% if not taking_screenshot %}


### PR DESCRIPTION
So that we can track IE11 users in a privacy-friendly way.