### PR TITLE
Fix: SQL query correctly groups by date

### DIFF
--- a/euctr/crawl/tests/test_get_trials_from_db.py
+++ b/euctr/crawl/tests/test_get_trials_from_db.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import datetime
 import os
 import pandas as pd
 import numpy as np
@@ -16,3 +17,43 @@ class GetTrialsFromDbTestCase(TestCase):
         # use the old 0.19.2 pandas undocumented function
         # rather than the 0.20 public function with a similar name
         pdt.assert_frame_equal(df_output, df_test_output)
+
+    def test_calculate_sufficiently_old(self):
+        scrape_dates = [
+            datetime.date(2021, 1, 1),
+            datetime.date(2020, 12, 1),
+            datetime.date(2020, 11, 1),
+        ]
+
+        last_scrape_date = scrape_dates[0]
+        verbosity = 0
+        sufficiently_old = euctr.management.commands.get_trials_from_db.calculate_sufficiently_old(scrape_dates, last_scrape_date, verbosity)
+
+        assert(sufficiently_old == datetime.date(2020, 11, 1))
+
+    def test_calculate_sufficiently_old_60_days(self):
+        scrape_dates = [
+            datetime.date(2021, 1, 1),
+            datetime.date(2020, 12, 1),
+            datetime.date(2020, 11, 6),
+            datetime.date(2020, 11, 5),
+            datetime.date(2020, 11, 4),
+            datetime.date(2020, 11, 3),
+            datetime.date(2020, 11, 2),
+            datetime.date(2020, 11, 1),
+        ]
+
+        last_scrape_date = scrape_dates[0]
+        verbosity = 0
+        sufficiently_old = euctr.management.commands.get_trials_from_db.calculate_sufficiently_old(scrape_dates, last_scrape_date, verbosity)
+        assert(sufficiently_old == datetime.date(2020, 11, 2))
+
+    def test_calculate_sufficiently_insufficient_count(self):
+        scrape_dates = [
+            datetime.date(2021, 1, 1),
+        ]
+
+        last_scrape_date = scrape_dates[0]
+        verbosity = 0
+        sufficiently_old = euctr.management.commands.get_trials_from_db.calculate_sufficiently_old(scrape_dates, last_scrape_date, verbosity)
+        assert(sufficiently_old == datetime.date(2020, 12, 31))

--- a/euctr/euctr/management/commands/get_trials_from_db.py
+++ b/euctr/euctr/management/commands/get_trials_from_db.py
@@ -234,9 +234,9 @@ class Command(BaseCommand):
         cur = conn.cursor()
         # Find out the start date of current scrape.
         cur.execute(
-            "select date(meta_updated) from euctr "
-            "group by meta_updated "
-            "order by meta_updated desc limit 60")
+            "select distinct date(meta_updated) as dmu from euctr "
+            "group by dmu "
+            "order by dmu desc limit 60")
         scrape_dates = [x[0] for x in cur.fetchall()]
         # Default to the oldest of the last 60 runs
         sufficiently_old = scrape_dates[-1]

--- a/euctr/euctr/management/commands/get_trials_from_db.py
+++ b/euctr/euctr/management/commands/get_trials_from_db.py
@@ -21,6 +21,36 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.template.defaultfilters import slugify
 
+def calculate_sufficiently_old(scrape_dates, last_scrape_date, verbosity):
+    """return the oldest scrape date that we should consider"""
+    # Default to the oldest of the last 60 runs
+    sufficiently_old = scrape_dates[-1]
+
+    # sufficiently_old: the date that is both more than 60 days
+    # ago *and* more than 2 scrapes old. We assume such trials not
+    # longer exist. The hand-waving around 60 days and 2 scrapes
+    # is because some trials apparently reappear. See #66 for
+    # discussion and analysis.
+    scrape_index = 0
+    scrape_window = 3
+    for d in scrape_dates:
+        scrape_index += 1
+        if d > (last_scrape_date - datetime.timedelta(days=60)):
+            # Disregard dates in the last 2 months
+            continue
+        if scrape_index >= scrape_window:
+            sufficiently_old = d
+            break
+    if scrape_index < scrape_window \
+       or last_scrape_date == sufficiently_old:
+        # There's not been enough scrapes to expire anything, so
+        # expire nothing
+        sufficiently_old = sufficiently_old - datetime.timedelta(days=1)
+    if verbosity > 1:
+        print("Will skip trials older than:", sufficiently_old)
+
+    return sufficiently_old
+
 def load_data_into_pandas(db, sufficiently_old):
     """load data from postgresql db"""
     engine = create_engine(db)
@@ -238,41 +268,12 @@ class Command(BaseCommand):
             "group by dmu "
             "order by dmu desc limit 60")
         scrape_dates = [x[0] for x in cur.fetchall()]
-        # Default to the oldest of the last 60 runs
-        sufficiently_old = scrape_dates[-1]
-        last_scrape_date = scrape_dates.pop(0)
+
+        last_scrape_date = scrape_dates[0]
         if verbosity > 1:
             print("Late scrape start date:", last_scrape_date)
 
-        # sufficiently_old: the date that is both more than 60 days
-        # ago *and* more than 2 scrapes old. We assume such trials not
-        # longer exist. The hand-waving around 60 days and 2 scrapes
-        # is because some trials apparently reappear. See #66 for
-        # discussion and analysis.
-        scrape_index = 0
-        scrape_window = 3
-        for d in scrape_dates:
-            scrape_index += 1
-            if d > (last_scrape_date - datetime.timedelta(days=60)):
-                # Disregard dates in the last 2 months
-                continue
-            if scrape_index >= scrape_window:
-                sufficiently_old = d
-                break
-        if scrape_index < scrape_window \
-           or last_scrape_date == sufficiently_old:
-            # There's not been enough scrapes to expire anything, so
-            # expire nothing
-            sufficiently_old = sufficiently_old - datetime.timedelta(days=1)
-        if verbosity > 1:
-            print("Will skip trials older than:", sufficiently_old)
-
-        # Date for reporting to be due has cutoff is 1 year (365 days) (by law,
-        # trials must report a year after finishing) plus 4 weeks (28 days)
-        # allowance (it takes that long for submissions to enter register)
-        due_date_cutoff = pd.Timestamp(last_scrape_date - relativedelta(years=1) - datetime.timedelta(days=28))
-        if verbosity > 1:
-            print("Due date cutoff:", due_date_cutoff)
+        sufficiently_old = calculate_sufficiently_old(scrape_dates, last_scrape_date, verbosity)
 
         euctr_cond = load_data_into_pandas(opentrials_db, sufficiently_old)
 
@@ -286,6 +287,14 @@ class Command(BaseCommand):
         spon_status = create_spon_status(spon_type)
 
         grouped = create_dataframe(euctr_cond)
+
+        # Date for reporting to be due has cutoff is 1 year (365 days) (by law,
+        # trials must report a year after finishing) plus 4 weeks (28 days)
+        # allowance (it takes that long for submissions to enter register)
+        due_date_cutoff = pd.Timestamp(last_scrape_date - relativedelta(years=1) - datetime.timedelta(days=28))
+        if verbosity > 1:
+            print("Due date cutoff:", due_date_cutoff)
+
         clean_and_enhance_dataframe(grouped, due_date_cutoff, euctr_url)
         
         final_cols = ['trial_id', 'number_of_countries', 'min_end_date', 'max_end_date', 'comp_date', 


### PR DESCRIPTION
* grouping by `meta_updated` gives lots of duplicate dates, which is clearly not the intention of this code
* verified on production data
```
(venv) root@smallweb1:/var/www/eutrialstracker_live/euctr-tracker-code/euctr# ./manage.py get_trials_from_db -v 2
Late scrape start date: 2021-08-07
Will skip trials older than: 2021-06-05
Due date cutoff: 2020-07-10 00:00:00
...
```
* fixes #114 
