### PR TITLE
Fixing dead link

### DIFF
--- a/euctr/templates/about.html
+++ b/euctr/templates/about.html
@@ -33,7 +33,7 @@
           and patients see only a partial, biased fraction of the true
           evidence. We cannot make informed decisions about treatments
           unless all the data is reported.  Under 
-                <a href="https://ec.europa.eu/health/sites/health/files/files/eudralex/vol-10/2012_302-03/2012_302-03_en.pdf">EU rules</a>, from
+                <a href="https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:52012XC1006(01)&from=EN">EU rules</a>, from
           December 2016, all trials on
           the <a href="https://www.clinicaltrialsregister.eu">European
           Union Clinical Trials Register</a> (EUCTR) should post


### PR DESCRIPTION
Link to 2012 guidelines was dead. Replaced with new working link.