### PR TITLE
feat: add OpenTelemetry/Honeycomb monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ rundev
 ghostdriver.log
 __pycache__/
 fixtures/euctr/4f/4ff2c188ce8d0558bf49ce65ba607b1a84e35f95/response_body
+.DS_Store

--- a/euctr/crawl/collector.py
+++ b/euctr/crawl/collector.py
@@ -2,10 +2,22 @@
 from scrapy.crawler import CrawlerProcess
 from .spider import Spider
 
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 # Module API
 
 def collect(conf, conn, date_from=None, date_to=None, query=None):
+    trace.set_tracer_provider(TracerProvider())
+    tracer = trace.get_tracer_provider().get_tracer(__name__)
+
+    trace.get_tracer_provider().add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter())
+    )
+
     process = CrawlerProcess(conf['SCRAPY_SETTINGS'])
     process.crawl(Spider, conf=conf, conn=conn, date_from=date_from, date_to=date_to, query=query)
     process.start()

--- a/euctr/crawl/parser.py
+++ b/euctr/crawl/parser.py
@@ -183,6 +183,8 @@ def parse_record(res):
 def trial_errback(failure):
     tracer = trace.get_tracer(__name__)
     with tracer.start_as_current_span("trial_errback"):
+        span = trace.get_current_span()
+
         request = failure.request
         span.set_attribute("url", request.url)
 
@@ -190,6 +192,7 @@ def trial_errback(failure):
         span.set_attribute("eudract_number_with_country", eudract_number_with_country)
 
         if failure.check(HttpError):
+            span.set_attribute('error', 'HttpError')
             span.set_attribute("status_code", failure.value.response.status)
 
         elif failure.check(DNSLookupError):

--- a/euctr/crawl/parser.py
+++ b/euctr/crawl/parser.py
@@ -183,19 +183,20 @@ def parse_record(res):
 def trial_errback(failure):
     tracer = trace.get_tracer(__name__)
     with tracer.start_as_current_span("trial_errback"):
-        eudract_number_with_country = '-'.join([failure.request.url.split('/')[-2], failure.request.url.split('/')[-1]])
+        request = failure.request
+        span.set_attribute("url", request.url)
+
+        eudract_number_with_country = '-'.join([request.url.split('/')[-2], request.url.split('/')[-1]])
         span.set_attribute("eudract_number_with_country", eudract_number_with_country)
 
         if failure.check(HttpError):
-            span.set_attribute("status_code", failure.value.response)
+            span.set_attribute("status_code", failure.value.response.status)
 
         elif failure.check(DNSLookupError):
-            request = failure.request
-            span.set_attribute('error', 'DNSLookupError on %s', request.url)
+            span.set_attribute('error', 'DNSLookupError')
 
         elif failure.check(TimeoutError, TCPTimedOutError):
-            request = failure.request
-            span.set_attribute('error', 'TimeoutError on %s', request.url)
+            span.set_attribute('error', 'TimeoutError')
 
 # Internal
 

--- a/euctr/crawl/parser.py
+++ b/euctr/crawl/parser.py
@@ -197,7 +197,6 @@ def trial_errback(failure):
             request = failure.request
             span.set_attribute('error', 'TimeoutError on %s', request.url)
 
-
 # Internal
 
 def _select_table(sel, ident):

--- a/euctr/crawl/parser.py
+++ b/euctr/crawl/parser.py
@@ -11,175 +11,173 @@ from opentelemetry import trace
 def parse_record(res):
     tracer = trace.get_tracer(__name__)
     with tracer.start_as_current_span("parse_record"):
-        parse_record_internal(res)
 
-def parse_record_internal(res):
-    span = trace.get_current_span()
-    span.set_attribute("url", res.url)
-    span.set_attribute("status_code", res.status)
+        span = trace.get_current_span()
+        span.set_attribute("url", res.url)
+        span.set_attribute("status_code", res.status)
 
-    fields_to_remove = [
-        'trial_other',
-        'trial_will_this_trial_be_conducted_at_a_single_site_globally',
-        'trial_will_this_trial_be_conducted_at_multiple_sites_globally',
-        'subject_number_of_subjects_for_this_age_range',
-        'subject_trial_has_subjects_under_18',
-        'subject_in_utero',
-        'subject_preterm_newborn_infants_up_to_gestational_age_37_weeks',
-        'subject_newborns_0_27_days',
-        'subject_infants_and_toddlers_28_days_23_months',
-        'subject_children_2_11years',
-        'subject_adolescents_12_17_years',
-        'subject_adults_18_64_years',
-        'subject_elderly_65_years',
-        'subject_women_of_child_bearing_potential_using_contraception',
-    ]
+        fields_to_remove = [
+            'trial_other',
+            'trial_will_this_trial_be_conducted_at_a_single_site_globally',
+            'trial_will_this_trial_be_conducted_at_multiple_sites_globally',
+            'subject_number_of_subjects_for_this_age_range',
+            'subject_trial_has_subjects_under_18',
+            'subject_in_utero',
+            'subject_preterm_newborn_infants_up_to_gestational_age_37_weeks',
+            'subject_newborns_0_27_days',
+            'subject_infants_and_toddlers_28_days_23_months',
+            'subject_children_2_11years',
+            'subject_adolescents_12_17_years',
+            'subject_adults_18_64_years',
+            'subject_elderly_65_years',
+            'subject_women_of_child_bearing_potential_using_contraception',
+        ]
 
-    # Init data item
-    data = {}
+        # Init data item
+        data = {}
 
-    # Summary
+        # Summary
 
-    kpath = '.cellGrey'
-    vpath = '.cellGrey+.cellLighterGrey'
-    subdata = _parse_dict(res, kpath, vpath)
-    # Some trials are badly formed:
-    # https://www.clinicaltrialsregister.eu/ctr-search/trial/2012-001258-25/results
-    if 'eudract_number' not in subdata:
-        return None
-    eudract_number = subdata['eudract_number']
-    data.update(subdata)
-    span.set_attribute("eudract_number", eudract_number)
+        kpath = '.cellGrey'
+        vpath = '.cellGrey+.cellLighterGrey'
+        subdata = _parse_dict(res, kpath, vpath)
+        # Some trials are badly formed:
+        # https://www.clinicaltrialsregister.eu/ctr-search/trial/2012-001258-25/results
+        if 'eudract_number' not in subdata:
+            return None
+        eudract_number = subdata['eudract_number']
+        data.update(subdata)
+        span.set_attribute("eudract_number", eudract_number)
 
-    key = 'eudract_number_with_country'
-    value = '-'.join([eudract_number, res.url.split('/')[-1]])
-    data.update({key: value})
-    span.set_attribute("eudract_number_with_country", value)
+        key = 'eudract_number_with_country'
+        value = '-'.join([eudract_number, res.url.split('/')[-1]])
+        data.update({key: value})
+        span.set_attribute("eudract_number_with_country", value)
 
-    # Trial results URL
+        # Trial results URL
 
-    key = '.summary a::attr(href)'
-    value = res.css(key).extract_first()
-    if value:
-        data['trial_results_url'] = urlparse.urljoin(res.url, value)
+        key = '.summary a::attr(href)'
+        value = res.css(key).extract_first()
+        if value:
+            data['trial_results_url'] = urlparse.urljoin(res.url, value)
 
-    # A. Protocol Information
+        # A. Protocol Information
 
-    ident = 'section-a'
-    kpath = '.second'
-    vpath = '.second+.third'
-    table = _select_table(res, ident)
-    subdata = _parse_dict(table, kpath, vpath)
-    data.update(subdata)
+        ident = 'section-a'
+        kpath = '.second'
+        vpath = '.second+.third'
+        table = _select_table(res, ident)
+        subdata = _parse_dict(table, kpath, vpath)
+        data.update(subdata)
 
-    # B. Sponsor information
+        # B. Sponsor information
 
-    key = 'sponsors'
-    ident = 'section-b'
-    kpath = '.second'
-    vpath = '.second+.third'
-    first = 'name_of_sponsor'
-    table = _select_table(res, ident)
-    value = _parse_list(table, kpath, vpath, first)
-    data.update({key: value})
+        key = 'sponsors'
+        ident = 'section-b'
+        kpath = '.second'
+        vpath = '.second+.third'
+        first = 'name_of_sponsor'
+        table = _select_table(res, ident)
+        value = _parse_list(table, kpath, vpath, first)
+        data.update({key: value})
 
-    # C. Applicant Identification
+        # C. Applicant Identification
 
-    # ...
+        # ...
 
-    # D. IMP Identification
+        # D. IMP Identification
 
-    key = 'imps'
-    ident = 'section-d'
-    kpath = '.second'
-    vpath = '.second+.third'
-    first = 'imp_role'
-    table = _select_table(res, ident)
-    value = _parse_list(table, kpath, vpath, first)
-    data.update({key: value})
+        key = 'imps'
+        ident = 'section-d'
+        kpath = '.second'
+        vpath = '.second+.third'
+        first = 'imp_role'
+        table = _select_table(res, ident)
+        value = _parse_list(table, kpath, vpath, first)
+        data.update({key: value})
 
-    # D8. Information on Placebo
+        # D8. Information on Placebo
 
-    key = 'placebos'
-    ident = 'section-d8'
-    kpath = '.second'
-    vpath = '.second+.third'
-    first = 'is_a_placebo_used_in_this_trial'
-    table = _select_table(res, ident)
-    value = _parse_list(table, kpath, vpath, first)
-    data.update({key: value})
+        key = 'placebos'
+        ident = 'section-d8'
+        kpath = '.second'
+        vpath = '.second+.third'
+        first = 'is_a_placebo_used_in_this_trial'
+        table = _select_table(res, ident)
+        value = _parse_list(table, kpath, vpath, first)
+        data.update({key: value})
 
-    # E. General Information on the Trial
+        # E. General Information on the Trial
 
-    ident = 'section-e'
-    kpath = '.second'
-    vpath = '.second+.third'
-    prefix = 'trial_'
-    table = _select_table(res, ident)
-    subdata = _parse_dict(table, kpath, vpath, prefix)
-    data.update(subdata)
+        ident = 'section-e'
+        kpath = '.second'
+        vpath = '.second+.third'
+        prefix = 'trial_'
+        table = _select_table(res, ident)
+        subdata = _parse_dict(table, kpath, vpath, prefix)
+        data.update(subdata)
 
-    # F. Population of Trial Subjects
+        # F. Population of Trial Subjects
 
-    ident = 'section-f'
-    kpath = '.second'
-    vpath = '.second+.third'
-    prefix = 'subject_'
-    table = _select_table(res, ident)
-    subdata = _parse_dict(table, kpath, vpath, prefix)
-    data.update(subdata)
+        ident = 'section-f'
+        kpath = '.second'
+        vpath = '.second+.third'
+        prefix = 'subject_'
+        table = _select_table(res, ident)
+        subdata = _parse_dict(table, kpath, vpath, prefix)
+        data.update(subdata)
 
-    code = 'F.1.1'
-    key = 'subject_childs'
-    value = _parse_value(table, code, index=1)
-    subdata[key] = value
+        code = 'F.1.1'
+        key = 'subject_childs'
+        value = _parse_value(table, code, index=1)
+        subdata[key] = value
 
-    code = 'F.1.2.1'
-    key = 'subject_adults'
-    value = _parse_value(table, code)
-    subdata[key] = value
+        code = 'F.1.2.1'
+        key = 'subject_adults'
+        value = _parse_value(table, code)
+        subdata[key] = value
 
-    code = 'F.1.3.1'
-    key = 'subject_elderly'
-    value = _parse_value(table, code)
-    subdata[key] = value
+        code = 'F.1.3.1'
+        key = 'subject_elderly'
+        value = _parse_value(table, code)
+        subdata[key] = value
 
-    data.update(subdata)
+        data.update(subdata)
 
-    # G. Investigator Networks to be involved in the Trial
+        # G. Investigator Networks to be involved in the Trial
 
-    # ...
+        # ...
 
-    # N. Review by the Competent Authority or Ethics Committee
+        # N. Review by the Competent Authority or Ethics Committee
 
-    ident = 'section-n'
-    kpath = '.second'
-    vpath = '.second+.third'
-    table = _select_table(res, ident)
-    subdata = _parse_dict(table, kpath, vpath)
-    data.update(subdata)
+        ident = 'section-n'
+        kpath = '.second'
+        vpath = '.second+.third'
+        table = _select_table(res, ident)
+        subdata = _parse_dict(table, kpath, vpath)
+        data.update(subdata)
 
-    # P. End of Trial
+        # P. End of Trial
 
-    ident = 'section-p'
-    kpath = '.second'
-    vpath = '.second+.third'
-    table = _select_table(res, ident)
-    subdata = _parse_dict(table, kpath, vpath)
-    data.update(subdata)
+        ident = 'section-p'
+        kpath = '.second'
+        vpath = '.second+.third'
+        table = _select_table(res, ident)
+        subdata = _parse_dict(table, kpath, vpath)
+        data.update(subdata)
 
-    # Update data
-    data['eudract_number'] = eudract_number
+        # Update data
+        data['eudract_number'] = eudract_number
 
-    # Remove data
-    for key in fields_to_remove:
-        if key in data:
-            del data[key]
+        # Remove data
+        for key in fields_to_remove:
+            if key in data:
+                del data[key]
 
-    # Create record
-    record = Record.create(res.url, data)
+        # Create record
+        record = Record.create(res.url, data)
 
-    return record
+        return record
 
 
 # Internal

--- a/euctr/crawl/spider.py
+++ b/euctr/crawl/spider.py
@@ -6,7 +6,7 @@ from datetime import date, timedelta
 from scrapy.spiders import Rule
 from scrapy.spiders import CrawlSpider
 from scrapy.linkextractors import LinkExtractor
-from crawl.parser import parse_record
+from crawl.parser import parse_record, trial_errback
 
 
 # Module API
@@ -36,7 +36,8 @@ class Spider(CrawlSpider):
                     allow=r'ctr-search/trial/[\d-]+/[\w]+',
                     deny=r'results$'
                 ),
-                callback=parse_record
+                callback=parse_record,
+                errback=trial_errback
             ),
             Rule(
                 LinkExtractor(

--- a/fabfile.py
+++ b/fabfile.py
@@ -24,7 +24,7 @@ def make_directory():
     run('mkdir -p %s' % (env.path))
 
 def venv_init():
-    run('[ -e venv ] || python3.5 -m venv venv')
+    run('[ -e venv ] || python3.6 -m venv venv')
 
 def pip_install():
     with prefix('source venv/bin/activate'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,6 @@ attrs==19.2.0
 Automat==0.8.0
 Twisted==20.3.0
 six==1.11.0
+opentelemetry_api==1.9.1
+opentelemetry-sdk==1.9.1
+opentelemetry-exporter-otlp-proto-grpc==1.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ selenium==3.5.0
 atomicwrites==1.1.5
 xlrd==1.1.0
 xlwt==1.3.0
-scrapy==1.5.1
+scrapy==2.0.0
 sqlalchemy==1.3.0
 dataset==1.0.1
 scrapy-crawlera==1.2.4


### PR DESCRIPTION
* super-simple, but wanted to try it production
* requires python 3.6 for OpenTelemetry dependencies
* requires scrapy v2.0.0 for `Rule` with `errback` param in order to monitor requests that error
* monitors trial page responses, does not monitor index page responses, more fiddly to get working & not necessarily required for MVP