### PR TITLE
Update get_trials_from_db.py

### DIFF
--- a/euctr/euctr/management/commands/get_trials_from_db.py
+++ b/euctr/euctr/management/commands/get_trials_from_db.py
@@ -76,7 +76,7 @@ def load_data_into_pandas(db, sufficiently_old):
 
 def cleanup_dataset(euctr_cond):
     """cleaning up the condensed EUCTR dataset and adding the false conditions"""
-    euctr_cond['date_of_the_global_end_of_the_trial'] = pd.to_datetime(euctr_cond['date_of_the_global_end_of_the_trial'])
+    euctr_cond['date_of_the_global_end_of_the_trial'] = pd.to_datetime(euctr_cond['date_of_the_global_end_of_the_trial'], errors = 'coerce')
     euctr_cond['trial_is_part_of_a_paediatric_investigation_plan'] = (euctr_cond['trial_is_part_of_a_paediatric_investigation_plan'] == True).astype(int)
     euctr_cond['trial_human_pharmacology_phase_i'] = (euctr_cond['trial_human_pharmacology_phase_i']== True).astype(int)
     euctr_cond['trial_therapeutic_exploratory_phase_ii'] = (euctr_cond['trial_therapeutic_exploratory_phase_ii']== True).astype(int)


### PR DESCRIPTION
The function `cleanup_dataset`, which works post-scrape during data handling, is breaking due to bad date data. A date (not sure which trial yet) is showing up as `202-04-30` which `pd.to_datetime` doesn't like.

If we can find the trial we might be able to make a good guess at what that date should be, but that is annoying and finnicky anyway. I'm comfortable, therefore, with using the built-in error handling in Pandas to coerce a broken date to a `NaT`. A broken date might as well not exist for us so lets treat it as if that is the case.